### PR TITLE
Migrate to use order-profile context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `order-profile` context to update the user profile in the orderForm.
+
 ## [0.1.0] - 2020-03-03
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "vtex.checkout-graphql": "0.x",
     "vtex.checkout-resources": "0.x",
+    "vtex.order-profile": "0.x",
     "vtex.styleguide": "9.x",
     "vtex.store-components": "3.x"
   },

--- a/react/Identification.tsx
+++ b/react/Identification.tsx
@@ -4,7 +4,7 @@ import { useLazyQuery } from 'react-apollo'
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl'
 import { IconCheck, Input, Button, Divider, Spinner } from 'vtex.styleguide'
 import { useChildBlock, ExtensionPoint, useRuntime } from 'vtex.render-runtime'
-import { OrderProfile } from 'vtex.order-profile'
+import { useOrderProfile } from 'vtex.order-profile/OrderProfile'
 import ProfileQuery from 'vtex.checkout-resources/QueryProfile'
 import {
   CheckoutProfile,
@@ -51,7 +51,7 @@ const Identification: React.FC = () => {
     { checkoutProfile: CheckoutProfile },
     QueryCheckoutProfileArgs
   >(ProfileQuery)
-  const { setOrderProfile } = OrderProfile.useOrderProfile()
+  const { setOrderProfile } = useOrderProfile()
 
   const [email, setEmail] = useState('')
   const [showError, setShowError] = useState(false)
@@ -87,7 +87,9 @@ const Identification: React.FC = () => {
     let isCurrent = true
 
     if (data.checkoutProfile?.userProfileId != null) {
-      setOrderProfile(data.checkoutProfile?.userProfile?.email).then(() => {
+      setOrderProfile({
+        email: data.checkoutProfile?.userProfile?.email ?? '',
+      }).then(() => {
         if (!isCurrent) {
           return
         }

--- a/react/package.json
+++ b/react/package.json
@@ -15,11 +15,11 @@
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
     "@types/react": "^16.9.23",
-    "vtex.checkout-graphql": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-graphql@0.24.0+build1583340197/public/@types/vtex.checkout-graphql",
-    "vtex.checkout-resources": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-resources@0.20.3+build1583340193/public/@types/vtex.checkout-resources",
-    "vtex.order-profile": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.order-profile@0.0.0+build1583340597/public/@types/vtex.order-profile",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.4/public/@types/vtex.checkout-resources",
+    "vtex.order-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.1.0/public/@types/vtex.order-profile",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.104.3/public/_types/react",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.0/public/_types/react",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.7/public/@types/vtex.styleguide"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -15,8 +15,9 @@
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
     "@types/react": "^16.9.23",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.0/public/@types/vtex.checkout-graphql",
-    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.1/public/@types/vtex.checkout-resources",
+    "vtex.checkout-graphql": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-graphql@0.24.0+build1583340197/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-resources": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-resources@0.20.3+build1583340193/public/@types/vtex.checkout-resources",
+    "vtex.order-profile": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.order-profile@0.0.0+build1583340597/public/@types/vtex.order-profile",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.104.3/public/_types/react",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.7/public/@types/vtex.styleguide"

--- a/react/package.json
+++ b/react/package.json
@@ -17,8 +17,8 @@
     "@types/react": "^16.9.23",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.0/public/@types/vtex.checkout-graphql",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.1/public/@types/vtex.checkout-resources",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.93.2/public/@types/vtex.render-runtime",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime",
     "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.104.3/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.6/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.7/public/@types/vtex.styleguide"
   }
 }

--- a/react/typings/vtex.order-profile.d.ts
+++ b/react/typings/vtex.order-profile.d.ts
@@ -1,0 +1,4 @@
+declare module 'vtex.order-profile/OrderProfile' {
+  export * from 'vtex.order-profile/react/OrderProfile'
+  export { default } from 'vtex.order-profile/react/OrderProfile'
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -411,25 +411,25 @@ tslib@^1.10.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-"vtex.checkout-graphql@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-graphql@0.24.0+build1583340197/public/@types/vtex.checkout-graphql":
-  version "0.24.0"
-  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-graphql@0.24.0+build1583340197/public/@types/vtex.checkout-graphql#9e821e77ee30bb0a42e36e67298fc5a4bb68dd45"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql":
+  version "0.24.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql#e970aec45ec8062587fc7d1ad73a6b93ab2ea26a"
 
-"vtex.checkout-resources@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-resources@0.20.3+build1583340193/public/@types/vtex.checkout-resources":
-  version "0.20.3"
-  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-resources@0.20.3+build1583340193/public/@types/vtex.checkout-resources#165451e8ecfbce2e9c17fac80447d98beb57ff05"
+"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.4/public/@types/vtex.checkout-resources":
+  version "0.20.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.4/public/@types/vtex.checkout-resources#40f3e5b66d7083e249e9235a262b3e49af40e437"
 
-"vtex.order-profile@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.order-profile@0.0.0+build1583340597/public/@types/vtex.order-profile":
-  version "0.0.0"
-  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.order-profile@0.0.0+build1583340597/public/@types/vtex.order-profile#a5ab7003513d5f1c008b0eddeef55fb82694335b"
+"vtex.order-profile@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.1.0/public/@types/vtex.order-profile":
+  version "0.1.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-profile@0.1.0/public/@types/vtex.order-profile#c0f4fa09af336fc6bc98782c5396dcb600c797af"
 
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime":
   version "8.94.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime#e79eb9a66801476b66e7ed354a83a7ff1f1c72c7"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.104.3/public/_types/react":
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.0/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.104.3/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.105.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.7/public/@types/vtex.styleguide":
   version "9.112.7"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -419,14 +419,14 @@ tslib@^1.10.0, tslib@^1.9.3:
   version "0.20.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.1/public/@types/vtex.checkout-resources#174c30341a50e5ca77fe4f038124a6cb17b810d1"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.93.2/public/@types/vtex.render-runtime":
-  version "8.93.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.93.2/public/@types/vtex.render-runtime#58d534da726c650b57017b311b14f89e92607a2a"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime":
+  version "8.94.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime#e79eb9a66801476b66e7ed354a83a7ff1f1c72c7"
 
 "vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.104.3/public/_types/react":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.104.3/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.6/public/@types/vtex.styleguide":
-  version "9.112.6"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.6/public/@types/vtex.styleguide#5d3e236c41b12b1bdbaaf5fa03d9882290fcf523"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.7/public/@types/vtex.styleguide":
+  version "9.112.7"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.7/public/@types/vtex.styleguide#882ace93cc403f2bc633b4e584d5d1dfbafaaeb0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -411,13 +411,17 @@ tslib@^1.10.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.0/public/@types/vtex.checkout-graphql":
+"vtex.checkout-graphql@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-graphql@0.24.0+build1583340197/public/@types/vtex.checkout-graphql":
   version "0.24.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.0/public/@types/vtex.checkout-graphql#37b5ba2720c336c1b3ec55832e3b0ebb45e8433b"
+  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-graphql@0.24.0+build1583340197/public/@types/vtex.checkout-graphql#9e821e77ee30bb0a42e36e67298fc5a4bb68dd45"
 
-"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.1/public/@types/vtex.checkout-resources":
-  version "0.20.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.1/public/@types/vtex.checkout-resources#174c30341a50e5ca77fe4f038124a6cb17b810d1"
+"vtex.checkout-resources@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-resources@0.20.3+build1583340193/public/@types/vtex.checkout-resources":
+  version "0.20.3"
+  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-resources@0.20.3+build1583340193/public/@types/vtex.checkout-resources#165451e8ecfbce2e9c17fac80447d98beb57ff05"
+
+"vtex.order-profile@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.order-profile@0.0.0+build1583340597/public/@types/vtex.order-profile":
+  version "0.0.0"
+  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.order-profile@0.0.0+build1583340597/public/@types/vtex.order-profile#a5ab7003513d5f1c008b0eddeef55fb82694335b"
 
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime":
   version "8.94.0"


### PR DESCRIPTION
#### What problem is this solving?
Updates the identification component to use the `setOrderProfile` function exposed from the `order-profile` context, instead of manually triggering the mutation, which can cause some concurrency issues that our order queue solves.

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32809/extrair-l%C3%B3gica-de-profile-do-checkout-identification)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout/identification)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->