### PR TITLE
Fix email not being updated in orderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Email not updated in orderForm if data wasn't autocompleted.
+
 ## [0.1.1] - 2020-03-05
 
 ### Changed

--- a/react/Identification.tsx
+++ b/react/Identification.tsx
@@ -86,23 +86,21 @@ const Identification: React.FC = () => {
 
     let isCurrent = true
 
-    if (data.checkoutProfile?.userProfileId != null) {
-      setOrderProfile({
-        email: data.checkoutProfile?.userProfile?.email ?? '',
-      }).then(() => {
-        if (!isCurrent) {
-          return
-        }
+    setOrderProfile({
+      email: data.checkoutProfile?.userProfile?.email ?? '',
+    }).then(() => {
+      if (!isCurrent) {
+        return
+      }
 
-        setLoading(false)
-
-        navigate({ page: 'store.checkout.container' })
-      })
-    } else {
       setLoading(false)
 
-      navigate({ page: 'store.checkout.container' })
-    }
+      navigate({
+        page: 'store.checkout.container',
+        query:
+          data.checkoutProfile?.userProfileId != null ? 'autocompleted=1' : '',
+      })
+    })
 
     return () => {
       isCurrent = false


### PR DESCRIPTION
#### What problem is this solving?
The email was only being updated in the orderForm when we were able to recover previous information about the user, but we should _always_ update the email, regardless of having information saved or not.

#### How should this be manually tested?
Go to [this workspace](https://lucas--checkoutio.myvtex.com/checkout/identification) and insert an email that isn't registered yet, and it should correctly update the clientProfileData with the inputed email.

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->