### PR TITLE
Updates to always update the profile attachment in orderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add user email to query `email` in redirect if userProfile is null.
+- Remove conditional to only update email in orderForm if `userProfileId !== null`.
 
 ## [0.1.1] - 2020-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add user email to query `email` in redirect if userProfile is null.
+
 ## [0.1.1] - 2020-03-05
 
 ### Changed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vtex-apps/checkout-ui

--- a/react/Identification.tsx
+++ b/react/Identification.tsx
@@ -86,9 +86,12 @@ const Identification: React.FC = () => {
 
     let isCurrent = true
 
-    if (data.checkoutProfile?.userProfileId != null) {
+    if (
+      data.checkoutProfile?.userProfileId != null &&
+      data.checkoutProfile.userProfile != null
+    ) {
       setOrderProfile({
-        email: data.checkoutProfile!.userProfile!.email,
+        email: data.checkoutProfile.userProfile.email,
       }).then(() => {
         if (!isCurrent) {
           return

--- a/react/Identification.tsx
+++ b/react/Identification.tsx
@@ -71,7 +71,9 @@ const Identification: React.FC = () => {
 
   const emailValid = EMAIL_REGEX.test(email)
 
-  const handleSubmit = () => {
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = evt => {
+    evt.preventDefault()
+
     if (!email || !emailValid) {
       return
     }

--- a/react/Identification.tsx
+++ b/react/Identification.tsx
@@ -88,7 +88,7 @@ const Identification: React.FC = () => {
 
     if (data.checkoutProfile?.userProfileId != null) {
       setOrderProfile({
-        email: data.checkoutProfile?.userProfile?.email ?? '',
+        email: data.checkoutProfile!.userProfile!.email,
       }).then(() => {
         if (!isCurrent) {
           return
@@ -101,7 +101,10 @@ const Identification: React.FC = () => {
     } else {
       setLoading(false)
 
-      navigate({ page: 'store.checkout.container' })
+      navigate({
+        page: 'store.checkout.container',
+        query: `email=${data.checkoutProfile?.userProfile?.email ?? ''}`,
+      })
     }
 
     return () => {

--- a/react/Identification.tsx
+++ b/react/Identification.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useLazyQuery } from 'react-apollo'
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl'
 import { IconCheck, Input, Button, Divider, Spinner } from 'vtex.styleguide'
@@ -54,6 +54,7 @@ const Identification: React.FC = () => {
   const { setOrderProfile } = useOrderProfile()
 
   const [email, setEmail] = useState('')
+  const emailRef = useRef(email)
   const [showError, setShowError] = useState(false)
   const [loading, setLoading] = useState(false)
   const hasLogoBlock = !!useChildBlock({ id: 'logo' })
@@ -63,6 +64,10 @@ const Identification: React.FC = () => {
   const handleEmailChange: React.ChangeEventHandler<HTMLInputElement> = evt => {
     setEmail(evt.target.value)
   }
+
+  useEffect(() => {
+    emailRef.current = email
+  }, [email])
 
   const emailValid = EMAIL_REGEX.test(email)
 
@@ -86,29 +91,17 @@ const Identification: React.FC = () => {
 
     let isCurrent = true
 
-    if (
-      data.checkoutProfile?.userProfileId != null &&
-      data.checkoutProfile.userProfile != null
-    ) {
-      setOrderProfile({
-        email: data.checkoutProfile.userProfile.email,
-      }).then(() => {
-        if (!isCurrent) {
-          return
-        }
+    setOrderProfile({
+      email: emailRef.current,
+    }).then(() => {
+      if (!isCurrent) {
+        return
+      }
 
-        setLoading(false)
-
-        navigate({ page: 'store.checkout.container' })
-      })
-    } else {
       setLoading(false)
 
-      navigate({
-        page: 'store.checkout.container',
-        query: `email=${data.checkoutProfile?.userProfile?.email ?? ''}`,
-      })
-    }
+      navigate({ page: 'store.checkout.container' })
+    })
 
     return () => {
       isCurrent = false


### PR DESCRIPTION
#### What problem is this solving?
This update the identification component to *always* update the `orderProfileData` attachment with the user's email on orderForm when the user presses the continue button, instead of only submiting it when `userProfileId !== null`. 

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout/identification).

1. Enter an email that don't have a profile associated yet.
2. Should redirect to `https://chkio--checkoutio.myvtex.com/checkout/#/profile`, and the email should appear in the "Profile" section of the steps.

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->