### PR TITLE
Fix route name for main checkout page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Route name for the main checkout page.
 
 ## [0.2.0] - 2020-04-17
 ### Added

--- a/react/Identification.tsx
+++ b/react/Identification.tsx
@@ -109,7 +109,7 @@ const Identification: React.FC = () => {
 
       setLoading(false)
 
-      navigate({ page: 'store.checkout.container' })
+      navigate({ page: 'store.checkout.order-form' })
     })
 
     return () => {


### PR DESCRIPTION
#### What problem is this solving?

The interface name for the main checkout page has changed from `store.checkout.container` to `store.checkout.order-form`, as of vtex-apps/checkout#43, and with it the redirect we do in the identification has stopped working. This PR addresses that.

#### How should this be manually tested?

1. Enter the [workspace](https://cartnavigate--checkoutio.myvtex.com/cart/add?sku=289).
2. Proceed to checkout.
3. Enter any email.
4. You should be redirected to Checkout, not the home page.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->